### PR TITLE
Add `create-wasm-app` bin so that `npm init wasm-app` works

### DIFF
--- a/.bin/create-wasm-app.js
+++ b/.bin/create-wasm-app.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+
+let folderName = '.';
+
+if (process.argv.length >= 3) {
+  folderName = process.argv[2];
+  if (!fs.existsSync(folderName)) {
+    fs.mkdirSync(folderName);
+  }
+}
+
+const clone = spawn("git", ["clone", "https://github.com/rustwasm/create-wasm-app.git", folderName]);
+
+clone.on("close", code => {
+  if (code !== 0) {
+    console.error("cloning the template failed!")
+    process.exit(code);
+  } else {
+    console.log("🦀 Rust + 🕸 Wasm = ❤");
+  }
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "create an app to consume rust-generated wasm packages",
   "main": "index.js",
+  "bin": {
+    "create-wasm-app": ".bin/create-wasm-app.js"
+  },
   "scripts": {
     "start": "webpack-dev-server"
   },


### PR DESCRIPTION
For `npm init foo` to work, there must be a bin named "create-foo". All this bin does is clone the template repo.

This will need to be published to npm again to complete the fix.