### PR TITLE
Change webpack version into fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "devDependencies": {
     "hello-wasm-pack": "^0.1.0",
-    "webpack": "^4.16.3",
+    "webpack": "^4.29.3",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5",
     "copy-webpack-plugin": "^4.5.2"


### PR DESCRIPTION
This fixes [webpack error]
(https://github.com/rustwasm/wasm_game_of_life/issues/22) due to the recent [rust-bindgen](https://github.com/rust-lang/rust-bindgen) update.
Change in the version desribed [here](https://github.com/webpack/webpack/pull/8786).

This change should enable all rust wasm tutorials throughout the internet with the command 
```bash
npm init wasm-app
```


