### PR TITLE
Update "Usage" section to mention project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rust-generated WebAssembly and using them to create a Website.
 ## 🚴 Usage
 
 ```
-npm init wasm-app
+npm init wasm-app <project-name>
 ```
 
 ## 🔋 Batteries Included


### PR DESCRIPTION
`npm init wasm-app` apparently fails without a project name given. See issue #44.