### PR TITLE
Add git error message to create-wasm-app

### DIFF
--- a/.bin/create-wasm-app.js
+++ b/.bin/create-wasm-app.js
@@ -14,9 +14,16 @@ if (process.argv.length >= 3) {
 
 const clone = spawn("git", ["clone", "https://github.com/rustwasm/create-wasm-app.git", folderName]);
 
+let errorMessage = '';
+clone.stderr.on('data',data=>{
+    errorMessage+=data;
+});
+
 clone.on("close", code => {
   if (code !== 0) {
-    console.error("cloning the template failed!")
+    console.error("cloning the template failed!");
+    errorMessage = errorMessage.replace('\n','\n    ');
+    console.log(`git output:\n    ${errorMessage}`)
     process.exit(code);
   } else {
     console.log("🦀 Rust + 🕸 Wasm = ❤");

--- a/.bin/create-wasm-app.js
+++ b/.bin/create-wasm-app.js
@@ -16,7 +16,7 @@ const clone = spawn("git", ["clone", "https://github.com/rustwasm/create-wasm-ap
 
 let errorMessage = '';
 clone.stderr.on('data', data => {
-    errorMessage+=data;
+    errorMessage += data;
 });
 
 clone.on("close", code => {

--- a/.bin/create-wasm-app.js
+++ b/.bin/create-wasm-app.js
@@ -22,7 +22,7 @@ clone.stderr.on('data', data => {
 clone.on("close", code => {
   if (code !== 0) {
     console.error("cloning the template failed!");
-    errorMessage = errorMessage.replace('\n','\n    ');
+    errorMessage = errorMessage.replace('\n', '\n    ');
     console.log(`git output:\n    ${errorMessage}`)
     process.exit(code);
   } else {

--- a/.bin/create-wasm-app.js
+++ b/.bin/create-wasm-app.js
@@ -15,7 +15,7 @@ if (process.argv.length >= 3) {
 const clone = spawn("git", ["clone", "https://github.com/rustwasm/create-wasm-app.git", folderName]);
 
 let errorMessage = '';
-clone.stderr.on('data',data=>{
+clone.stderr.on('data', data => {
     errorMessage+=data;
 });
 


### PR DESCRIPTION
When the `npm init wasm-app` command fails, there are now more useful error messages to aid debugging.