### PR TITLE
Add a <noscript> in default html.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>Hello wasm-pack!</title>
   </head>
   <body>
+    <noscript>This page contains webassembly and javascript content, please enable javascript in your browser.</noscript>
     <script src="./bootstrap.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The content of this noscript will be displayed only when end-user blocks Javascript (like with the `NoScript` add-on).