### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rust-generated WebAssembly and using them to create a Website.
 ## 🚴 Usage
 
 ```
-npm init wasm-app
+npm init wasm-app www
 ```
 
 ## 🔋 Batteries Included


### PR DESCRIPTION
The usage in Rust tutorial  `https://rustwasm.github.io/docs/book/game-of-life/hello-world.html#whats-inside` half way down 
has the usage as `npm init wasm-app www`

running usage as `npm init wasm-app` resulted in an error `cloning the template failed!`