### PR TITLE
Feature: Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start": "webpack-dev-server"
+    "start": "webpack serve"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "devDependencies": {
     "hello-wasm-pack": "^0.1.0",
-    "webpack": "^4.29.3",
-    "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "^3.1.5",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1",
+    "webpack-dev-server": "^4.11.1",
     "copy-webpack-plugin": "^5.0.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const path = require('path');
+const path = require("path");
 
 module.exports = {
   entry: "./bootstrap.js",
@@ -8,7 +8,16 @@ module.exports = {
     filename: "bootstrap.js",
   },
   mode: "development",
-  plugins: [
-    new CopyWebpackPlugin(['index.html'])
-  ],
+  plugins: [new CopyWebpackPlugin(["index.html"])],
+  experiments: {
+    asyncWebAssembly: true,
+    syncWebAssembly: true,
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
+    compress: true,
+    port: 3000,
+  },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,5 @@ module.exports = {
       directory: path.join(__dirname, "dist"),
     },
     compress: true,
-    port: 3000,
   },
 };


### PR DESCRIPTION
This PR resolves the [bug reports](https://paulyu.dev/article/fixing-node-digital-envelope-routines-error/) on the Node.js OpenSSL error `0308010c:digital envelope routines::unsupported` with Node 17+. 

There are [a few ways](https://weekendprojects.dev/posts/fixed-node-err_ossl_evp_unsupported/) to fix the error when running Webpack dev server and the most sensible solution is to upgrade Webpack to version 5.