### PR TITLE
fix: update `devDependencies` versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ Rust-generated WebAssembly and using them to create a Website.
 npm init wasm-app
 ```
 
+**Note**
+You may face error like below:
+```shell
+(node:257464) [DEP0111] DeprecationWarning: Access to process.binding('http_parser') is deprecated.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+ℹ ｢wds｣: Project is running at http://localhost:8080/
+ℹ ｢wds｣: webpack output is served from /
+node:internal/crypto/hash:69
+  this[kHandle] = new _Hash(algorithm, xofLen);
+  ...
+```
+That error because of `devDependencies` versions conflicted with you Node version.
+
+You can simply update `devDependencies` versions by below commands:
+```shell
+npm i -g npm-check-updates
+ncu -u
+npm install
+```
+Reference: https://stackoverflow.com/a/16074029/8093348 
+
+
 ## 🔋 Batteries Included
 
 - `.gitignore`: ignores `node_modules`

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "devDependencies": {
+    "copy-webpack-plugin": "^11.0.0",
     "hello-wasm-pack": "^0.1.0",
-    "webpack": "^4.29.3",
-    "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "^3.1.5",
-    "copy-webpack-plugin": "^5.0.0"
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,13 @@ module.exports = {
   },
   mode: "development",
   plugins: [
-    new CopyWebpackPlugin(['index.html'])
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: 'index.html' }
+      ]
+    })
   ],
+  experiments: {
+    asyncWebAssembly: true,
+  }
 };


### PR DESCRIPTION
- Updated last versions of `devDependencies`
- Updated `README.md` with notes about that to be avoided in the future.
- Updated `webpack.config.js` to activate WASM manually which from `webpack` 5, must activate it manually. Ref: https://webpack.js.org/configuration/experiments/